### PR TITLE
ci: add a commitlint step to make sure only correctly formatted commits are merged to master

### DIFF
--- a/.github/workflows/lint-merge-commit-name.yml
+++ b/.github/workflows/lint-merge-commit-name.yml
@@ -1,0 +1,14 @@
+name: Lint merge commit name
+
+on:
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  lint-commit-name:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wagoid/commitlint-github-action@v5
+        with:
+          commitDepth: 1


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/5711958525

This should, with the help of merge queue feature of GitHub, verify that the squashed commit to master is within the standards of commitlint